### PR TITLE
Making mapperConfigDefaults public

### DIFF
--- a/pkg/mapper/mapper.go
+++ b/pkg/mapper/mapper.go
@@ -43,7 +43,7 @@ var (
 
 type MetricMapper struct {
 	Registerer prometheus.Registerer
-	Defaults   mapperConfigDefaults `yaml:"defaults"`
+	Defaults   MapperConfigDefaults `yaml:"defaults"`
 	Mappings   []MetricMapping      `yaml:"mappings"`
 	FSM        *fsm.FSM
 	doFSM      bool

--- a/pkg/mapper/mapper_defaults.go
+++ b/pkg/mapper/mapper_defaults.go
@@ -15,7 +15,7 @@ package mapper
 
 import "time"
 
-type mapperConfigDefaults struct {
+type MapperConfigDefaults struct {
 	ObserverType        ObserverType     `yaml:"observer_type"`
 	MatchType           MatchType        `yaml:"match_type"`
 	GlobDisableOrdering bool             `yaml:"glob_disable_ordering"`
@@ -39,7 +39,7 @@ type mapperConfigDefaultsAlias struct {
 
 // UnmarshalYAML is a custom unmarshal function to allow use of deprecated config keys
 // observer_type will override timer_type
-func (d *mapperConfigDefaults) UnmarshalYAML(unmarshal func(interface{}) error) error {
+func (d *MapperConfigDefaults) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var tmp mapperConfigDefaultsAlias
 	if err := unmarshal(&tmp); err != nil {
 		return err


### PR DESCRIPTION
This is making the mapperConfigDefaults attribute inside MetricMapper object public, so that Grafana Agent or any other application embedding this exporter can instatiate MetricMapper without using the InitFromYAMLString directly.

This is really helpful when you are not defining your configuration using YAML standard.